### PR TITLE
[python-imaging] Upgrade to 2.9.0. Contributes to JB#30351

### DIFF
--- a/rpm/python-imaging.spec
+++ b/rpm/python-imaging.spec
@@ -4,8 +4,8 @@
 
 Summary:       Python's own image processing library
 Name:          python-imaging
-Version:       2.2.0
-Release:       14
+Version:       2.9.0
+Release:       1
 
 License:       BSD
 Group:         System/Libraries
@@ -79,7 +79,7 @@ popd
 
 
 %check
-PYTHONPATH=$(ls -1d build/lib.linux*) %{__python} selftest.py
+PYTHONPATH=$(ls -1d build/lib.linux*) %{__python} selftest.py --installed
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -88,7 +88,7 @@ rm -rf $RPM_BUILD_ROOT
 %files -f files.main
 %defattr (-,root,root,-)
 %dir %{python_sitearch}/PIL
-/usr/lib/python2.7/site-packages/Pillow-2.1.0-py2.7.egg-info
+/usr/lib/python2.7/site-packages/*.egg-info
 
 %files devel
 %defattr (0644,root,root,755)


### PR DESCRIPTION
Earlier version didn't work with upgraded freetype due to some custom path detection. This seems to compile both with current 2.4.x and wip 2.6.0.

Didn't test more than compilation and selftest executed as part of it. Not familiar with the module, so don't even know how to. But it compiles, thus it works, right?
